### PR TITLE
Allowed CanUpdate event to deny updates

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -460,7 +460,7 @@
 +        boolean isForced = getPersistentChunks().containsKey(new net.minecraft.util.math.ChunkPos(i >> 4, j >> 4));
 +        int k = isForced ? 0 : 32;
 +        boolean canUpdate = !p_72866_2_ || this.func_175663_a(i - k, 0, j - k, i + k, 0, j + k, true);
-+        if (!canUpdate) canUpdate = net.minecraftforge.event.ForgeEventFactory.canEntityUpdate(p_72866_1_);
++        canUpdate = net.minecraftforge.event.ForgeEventFactory.canEntityUpdate(p_72866_1_, canUpdate);
  
 -        if (!p_72866_2_ || this.func_175663_a(i - 32, 0, j - 32, i + 32, 0, j + 32, true))
 +        if (canUpdate)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -384,9 +384,9 @@ public class ForgeEventFactory
         return null;
     }
 
-    public static boolean canEntityUpdate(Entity entity)
+    public static boolean canEntityUpdate(Entity entity, boolean canUpdate)
     {
-        EntityEvent.CanUpdate event = new EntityEvent.CanUpdate(entity);
+        EntityEvent.CanUpdate event = new EntityEvent.CanUpdate(entity, canUpdate);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getCanUpdate();
     }

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -69,12 +69,11 @@ public class EntityEvent extends Event
 
     /**
      * CanUpdate is fired when an Entity is being created. <br>
-     * This event is fired whenever vanilla Minecraft determines that an entity<br>
-     * cannot update in {@link World#updateEntityWithOptionalForce(net.minecraft.entity.Entity, boolean)} <br>
+     * This event is fired every time an entity tries to update <br>
      * <br>
      * {@link CanUpdate#canUpdate} contains the boolean value of whether this entity can update.<br>
      * If the modder decides that this Entity can be updated, they may change canUpdate to true, <br>
-     * and the entity with then be updated.<br>
+     * and the entity with then be updated, or vice versa.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -82,10 +81,11 @@ public class EntityEvent extends Event
      **/
     public static class CanUpdate extends EntityEvent
     {
-        private boolean canUpdate = false;
-        public CanUpdate(Entity entity)
+        private boolean canUpdate;
+        public CanUpdate(Entity entity, boolean canUpdate)
         {
             super(entity);
+            this.canUpdate = canUpdate;
         }
 
         public boolean getCanUpdate()


### PR DESCRIPTION
Allowed CanUpdate event to be called whenever an entity tries to
update, not only when Minecraft decides that it shouldn’t. Also allowed
CanUpdate to deny updates instead of just allowing them.